### PR TITLE
Spark 3: Cache CDM Date and DateTime type methods

### DIFF
--- a/src/main/scala/com/microsoft/cdm/read/CDMSimpleScan.scala
+++ b/src/main/scala/com/microsoft/cdm/read/CDMSimpleScan.scala
@@ -48,9 +48,9 @@ class CDMSimpleScan(val storage: String,
 
   override def toBatch: Batch = this
 
-  def getReader(fType: String, uriPath: String, filePath: String, schema: StructType, serializedHadoopConf: SparkSerializableConfiguration, delimiter: Char): ReaderConnector ={
+  def getReader(fType: String, uriPath: String, filePath: String, schema: StructType, serializedHadoopConf: SparkSerializableConfiguration, delimiter: Char, hasHeader: Boolean): ReaderConnector ={
     return fType match {
-      case   "is.partition.format.CSV" => new CSVReaderConnector(uriPath, filePath, serializedHadoopConf, delimiter, mode)
+      case   "is.partition.format.CSV" => new CSVReaderConnector(uriPath, filePath, serializedHadoopConf, delimiter, mode, schema, hasHeader)
       case   "is.partition.format.parquet" => new ParquetReaderConnector(uriPath, filePath, schema, serializedHadoopConf)
     }
   }
@@ -79,8 +79,8 @@ class CDMSimpleScan(val storage: String,
       // Decode strings because hadoop cannot parse URI-encoded strings
       val decodedFilePath = URLDecoder.decode(manifestPath + relPath, "UTF-8")
 
-      //we track the header and pass it in to the reader so that we know if the first line is a header row
-      var header = false
+      //we track hasHeader and pass it in to the reader so that we know if the first line is a header row
+      var hasHeader = false
       val schema = readSchema();
       var delimiter = Constants.DEFAULT_DELIMITER
       val fileReader = {
@@ -94,7 +94,7 @@ class CDMSimpleScan(val storage: String,
           val arguments = traits.asInstanceOf[CdmTraitReference].getArguments().asScala
           val headerArg = arguments.find(_.getName() == "columnHeaders")
           if (headerArg != None) {
-            header = headerArg.get.getValue().toString.toBoolean
+            hasHeader = headerArg.get.getValue().toString.toBoolean
           }
           val delimiterArg = arguments.find(_.getName() == "delimiter")
           if (delimiterArg != None) {
@@ -102,18 +102,18 @@ class CDMSimpleScan(val storage: String,
             if(strDelimiter.length > 1) throw new IllegalArgumentException(String.format(Messages.invalidDelimiterCharacter, strDelimiter))
             delimiter = strDelimiter.charAt(0)
           }
-          val reader = getReader(traits.getNamedReference, uriPrefix, decodedFilePath, schema, serializedHadoopOConf, delimiter)
+          val reader = getReader(traits.getNamedReference, uriPrefix, decodedFilePath, schema, serializedHadoopOConf, delimiter, hasHeader)
           if (reader.isInstanceOf[ParquetReaderConnector] && Constants.PERMISSIVE.equalsIgnoreCase(mode)) {
             throw new IllegalArgumentException(String.format(Messages.invalidPermissiveMode))
           }
           reader
         } else {
           SparkCDMLogger.log(Level.DEBUG, "No Named Reference Trait \"is.partition.format\" (CSV/Parquet", logger)
-          new CSVReaderConnector(uriPrefix, decodedFilePath, serializedHadoopOConf, delimiter, mode)
+          new CSVReaderConnector(uriPrefix, decodedFilePath, serializedHadoopOConf, delimiter, mode, schema, hasHeader)
         }
       }
 
-      factoryList.add(new CDMInputPartition(storage, container, fileReader, header, readSchema(), dataConverter, mode))
+      factoryList.add(new CDMInputPartition(storage, container, fileReader, hasHeader, schema, dataConverter, mode))
     }
     SparkCDMLogger.log(Level.DEBUG, "Count of partitions - "+eDec.getDataPartitions.size() + " Entity - " + eDec.getEntityName + " Manifest -"+ man.getManifestName, logger)
     factoryList.asScala.toArray

--- a/src/main/scala/com/microsoft/cdm/read/CSVReaderConnector.scala
+++ b/src/main/scala/com/microsoft/cdm/read/CSVReaderConnector.scala
@@ -1,6 +1,5 @@
 package com.microsoft.cdm.read
 
-import java.net.URLDecoder
 import java.time.{Instant, LocalDate, LocalDateTime, LocalTime, ZoneId}
 import java.time.format.{DateTimeFormatter, DateTimeParseException}
 import java.time.temporal.ChronoUnit
@@ -9,42 +8,68 @@ import com.microsoft.cdm.log.SparkCDMLogger
 import com.univocity.parsers.csv.CsvParser
 import org.apache.hadoop.fs.Path
 import org.apache.parquet.hadoop.util.HadoopInputFile
-import org.apache.spark.sql.types.{BooleanType, ByteType, DataType, DateType, Decimal, DecimalType, DoubleType, FloatType, IntegerType, LongType, ShortType, StringType, TimestampType}
+import org.apache.spark.sql.types.{BooleanType, ByteType, DataType, DateType, Decimal, DecimalType, DoubleType, FloatType, IntegerType, LongType, ShortType, StringType, StructType, TimestampType}
 import org.apache.spark.unsafe.types.UTF8String
 import org.slf4j.LoggerFactory
 import org.slf4j.event.Level
+import scala.collection.mutable
 
-class CSVReaderConnector(httpPrefix:String, filePath: String, serConf:SparkSerializableConfiguration, delimiter: Char, mode: String) extends ReaderConnector {
+class CSVReaderConnector(httpPrefix:String, filePath: String, serConf:SparkSerializableConfiguration, delimiter: Char, mode: String, schema: StructType, hasHeader: Boolean) extends ReaderConnector {
   val logger  = LoggerFactory.getLogger(classOf[CSVReaderConnector])
   SparkCDMLogger.log(Level.DEBUG, "CSV Reader for partition at path: " + httpPrefix + filePath, logger)
 
   private var goodRow:Boolean = true
   private var parser: CsvParser = _
-  private val dateFormatStrings = List(
-    "yyyy-MM-dd",
-    "M/d/yyyy" )
 
-  private val localTimeFormatsNonStandard= List(
-    "M/d/yyyy H:mm",
-    "M/d/yyyy h:mm:ss a",
-    "M/d/yyyy H:mm:ss",
-    "yyyy-MM-dd H:mm:ss.S",
-    "yyyy-MM-dd H:mm:ss.SS",
-    "yyyy-MM-dd H:mm:ss.SSS",
-    "yyyy-MM-dd H:mm:ss.SSSS",
-    "yyyy-MM-dd H:mm:ss.SSSSS",
-    "yyyy-MM-dd H:mm:ss.SSSSSS",
-    "yyyy-MM-dd H:mm:ss",
-    "MMM d yyyy h:mma")
+  /**
+   * Map the index with a tuple (Any, Generic function)
+   * tuple._1 (Any) Format of value you are parsing
+   * tuple._2 (Generic function) Generic function to plug in format
+   */
+  private var indexToCachedDateFunction: Array[(Any, (String, Any, Int, String) => LocalDate)] = _
+  private var indexToCachedDateTimeFunction: Array[(Any, (String, Any, Int, String) => java.lang.Long)] = _
 
-  private val timeFormatStrings = List(
-    "HH:mm:ss",
-    "HH:mm:ss.S",
-    "HH:mm:ss.SS",
-    "HH:mm:ss.SSS",
-    "HH:mm:ss.SSSS",
-    "HH:mm:ss.SSSSS",
-    "HH:mm:ss.SSSSSS")
+  /**
+   * Formats have the format mapped to a generic function.
+   * The generic function will take in a format to perform the correct conversions
+   */
+  private lazy val dateFormatStrings : mutable.Map[String, (String, Any, Int, String) => LocalDate] = mutable.Map(
+    "yyyy-MM-dd" -> parseGenericDateCached1,
+    "M/d/yyyy" -> parseGenericDateCached1)
+
+  // @transient + lazy required to ensure that DateTimeFormatter is not serialized when sent to executor
+  @transient private lazy val localTimeFormats : mutable.Map[DateTimeFormatter, (String, Any, Int, String) => java.lang.Long] = mutable.Map(
+    DateTimeFormatter.ISO_OFFSET_DATE_TIME -> parseGenericDateTimeCached1,
+    DateTimeFormatter.ISO_INSTANT -> parseGenericDateTimeCached1)
+  
+  @transient private lazy val localTimeFormat2 : mutable.Map[DateTimeFormatter, (String, Any, Int, String) => java.lang.Long] = mutable.Map(
+    DateTimeFormatter.ISO_LOCAL_DATE_TIME -> parseGenericDateTimeCached2)
+
+  private lazy val localTimeFormatsNonStandard : mutable.Map[String, (String, Any, Int, String) => java.lang.Long] = mutable.Map(
+    "M/d/yyyy H:mm" -> parseGenericDateTimeCached3,
+    "M/d/yyyy h:mm:ss a" -> parseGenericDateTimeCached3,
+    "M/d/yyyy H:mm:ss" -> parseGenericDateTimeCached3,
+    "yyyy-MM-dd H:mm:ss.S" -> parseGenericDateTimeCached3,
+    "yyyy-MM-dd H:mm:ss.SS" -> parseGenericDateTimeCached3,
+    "yyyy-MM-dd H:mm:ss.SSS" -> parseGenericDateTimeCached3,
+    "yyyy-MM-dd H:mm:ss.SSSS" -> parseGenericDateTimeCached3,
+    "yyyy-MM-dd H:mm:ss.SSSSS" -> parseGenericDateTimeCached3,
+    "yyyy-MM-dd H:mm:ss.SSSSSS" -> parseGenericDateTimeCached3,
+    "yyyy-MM-dd H:mm:ss" -> parseGenericDateTimeCached3,
+    "MMM d yyyy h:mma" -> parseGenericDateTimeCached3)
+
+  private lazy val dateFormatStringsAsDateTime : mutable.Map[String, (String, Any, Int, String) => java.lang.Long] = mutable.Map(
+    "yyyy-MM-dd" -> parseGenericDateTimeCached4,
+    "M/d/yyyy" -> parseGenericDateTimeCached4)
+
+  private lazy val timeFormatStrings : mutable.Map[String, (String, Any, Int, String) => java.lang.Long] = mutable.Map(
+    "HH:mm:ss" -> parseGenericDateTimeCached5,
+    "HH:mm:ss.S" -> parseGenericDateTimeCached5,
+    "HH:mm:ss.SS" -> parseGenericDateTimeCached5,
+    "HH:mm:ss.SSS" -> parseGenericDateTimeCached5,
+    "HH:mm:ss.SSSS" -> parseGenericDateTimeCached5,
+    "HH:mm:ss.SSSSS" -> parseGenericDateTimeCached5,
+    "HH:mm:ss.SSSSSS" -> parseGenericDateTimeCached5)
 
   def build: Unit = {
     try {
@@ -55,12 +80,57 @@ class CSVReaderConnector(httpPrefix:String, filePath: String, serConf:SparkSeria
       parser.beginParsing {
         inputStream
       }
+      // Parse first row to catch methods
+      val tempStream = inputFile.newStream()
+      val tempParser = CsvParserFactory.build(delimiter)
+      tempParser.beginParsing {
+        tempStream
+      }
+      var temp = tempParser.parseNext()
+      if (hasHeader) { // if first row is a header, then read next
+        temp = tempParser.parseNext()
+      }
+      if (temp != null) { // if not null/CSV actually contains data, then set as first row
+        val firstRow = temp.asInstanceOf[Array[Any]]
+        // PARSE FIRST ROW
+        if (firstRow.length > schema.fields.length) {
+          schema.zipWithIndex.map{ case (col, index) =>
+            indexToCachedDateFunction = new Array[(Any, (String, Any, Int, String) => LocalDate)](schema.size)
+            indexToCachedDateTimeFunction = new Array[(Any, (String, Any, Int, String) => java.lang.Long)](schema.size)
+            val dataType = schema.fields(index).dataType
+            jsonToData(dataType, firstRow.apply(index), index, mode)
+          }
+        } else if (firstRow.length < schema.fields.length) {
+          // When there are fewer columns in the CSV file the # of attributes in cdm entity file at the end
+          schema.zipWithIndex.map{ case (col, index) =>
+            indexToCachedDateFunction = new Array[(Any, (String, Any, Int, String) => LocalDate)](schema.size)
+            indexToCachedDateTimeFunction = new Array[(Any, (String, Any, Int, String) => java.lang.Long)](schema.size)
+            if (index >= firstRow.length) {
+              null
+            } else {
+              val dataType = schema.fields(index).dataType
+              jsonToData(dataType, firstRow.apply(index), index, mode)
+            }
+          }
+        } else {
+          firstRow.zipWithIndex.map { case (col, index) =>
+            indexToCachedDateFunction = new Array[(Any, (String, Any, Int, String) => LocalDate)](firstRow.length)
+            indexToCachedDateTimeFunction = new Array[(Any, (String, Any, Int, String) => java.lang.Long)](firstRow.length)
+            val dataType = schema.fields(index).dataType
+            jsonToData(dataType, firstRow.apply(index), index, mode)
+          }
+        }
+        tempParser.stopParsing()
+        tempStream.close()
+      }
+
     } catch {
       case e: Throwable => SparkCDMLogger.log(Level.ERROR, e.printStackTrace.toString, logger)
     }
   }
 
   def close(): Unit = {
+    parser.stopParsing()
   }
 
   def readRow(): Array[Any] = {
@@ -79,7 +149,7 @@ class CSVReaderConnector(httpPrefix:String, filePath: String, serConf:SparkSeria
 
   def isValidRow(): Boolean = goodRow
 
-  def jsonToData(dt: DataType, value: Any, mode: String): Any= {
+  def jsonToData(dt: DataType, value: Any, schemaIndex: Int, mode: String): Any= {
     /* null is a valid value */
     if (value == null) {
       null
@@ -96,7 +166,15 @@ class CSVReaderConnector(httpPrefix:String, filePath: String, serConf:SparkSeria
         case BooleanType =>  util.Try(value.toString.toBoolean).getOrElse(null)
         case DateType => {
           if (value != None && value != null) {
-            val date = tryParseDate(value.toString, mode)
+            var date : LocalDate = null
+            if (indexToCachedDateFunction(schemaIndex) != null) {
+              val tuple = indexToCachedDateFunction(schemaIndex)
+              val format = tuple._1
+              val fx = tuple._2
+              date = fx(value.toString, format, schemaIndex, mode)
+            } else {
+              date = tryParseDate(value.toString, schemaIndex, mode)
+            }
 
             /* If we can't parse the date we return a null. This enables permissive mode to work*/
             if (date == null) {
@@ -111,7 +189,15 @@ class CSVReaderConnector(httpPrefix:String, filePath: String, serConf:SparkSeria
         case StringType => util.Try(UTF8String.fromString(value.toString)).getOrElse(null)
         case TimestampType => {
           if (value != None && value != null) {
-            val date = tryParseDateTime(value.toString, mode)
+            var date : java.lang.Long = null
+            if (indexToCachedDateTimeFunction(schemaIndex) != null) {
+              val tuple = indexToCachedDateTimeFunction(schemaIndex)
+              val format = tuple._1
+              val fx = tuple._2
+              date = fx(value.toString, format, schemaIndex, mode)
+            } else {
+              date = tryParseDateTime(value.toString, schemaIndex, mode)
+            }
 
             /* If we can't parse the date we return a null. This enables permissive mode to work*/
             if (date == null) {
@@ -142,18 +228,23 @@ class CSVReaderConnector(httpPrefix:String, filePath: String, serConf:SparkSeria
     }
   }
 
-  def tryParseDate(dateString: String, mode: String): LocalDate= {
-    for (formatString <- dateFormatStrings) {
+  /**
+   * Attempts to parse Date using all possible formats.
+   * Upon reaching the first successful parse, map the column index to a cached tuple (format, function).
+   */
+  def tryParseDate(dateString: String, index: Int, mode: String): LocalDate= {
+    for (formatString <- dateFormatStrings.keySet) {
       try {
           val dateTimeFormatter = DateTimeFormatter.ofPattern(formatString)
           val localDate= LocalDate.parse(dateString, dateTimeFormatter)
+          indexToCachedDateFunction(index) = (formatString, dateFormatStrings(formatString))
           return localDate
       } catch {
         case e: DateTimeParseException=>
       }
     }
 
-    val msg = "Mode: " + mode + ". Could not parse " + dateString + " using any possible format"
+    val msg = s"Mode: $mode. Could not parse \'$dateString\'. Data in this format is not supported."
     SparkCDMLogger.log(Level.ERROR,  msg, logger)
     if (Constants.FAILFAST.equalsIgnoreCase(mode)) {
       throw new IllegalArgumentException(msg)
@@ -161,21 +252,24 @@ class CSVReaderConnector(httpPrefix:String, filePath: String, serConf:SparkSeria
     null
   }
 
-  def tryParseDateTime(dateString: String, mode: String): java.lang.Long = {
-
-    val localTimeFormats = List(DateTimeFormatter.ISO_OFFSET_DATE_TIME,
-      DateTimeFormatter.ISO_INSTANT)
-
+  /**
+   * Attempts to parse DateTime using all possible formats.
+   * Upon reaching the first successful parse, map the column index to a cached tuple (format, function).
+   */
+  def tryParseDateTime(dateString: String, index: Int, mode: String): java.lang.Long = {
     /* Conversions that to local time first */
-    for (format <- localTimeFormats) {
+    for (format <- localTimeFormats.keySet) {
       var instant: Instant = null;
       try {
         val i = Instant.from(format.parse(dateString))
         val zt = i.atZone(ZoneId.systemDefault())
         instant = zt.toLocalDateTime.atZone(ZoneId.systemDefault()).toInstant();
-        return ChronoUnit.MICROS.between(Instant.EPOCH, instant)
+        val res = ChronoUnit.MICROS.between(Instant.EPOCH, instant)
+        indexToCachedDateTimeFunction(index) = (format, localTimeFormats(format))
+        return res
       } catch {
         case e: ArithmeticException => {
+          indexToCachedDateTimeFunction(index) = (format, localTimeFormats(format))
           return instant.toEpochMilli()*1000
         }
         case e: DateTimeParseException=>
@@ -183,14 +277,17 @@ class CSVReaderConnector(httpPrefix:String, filePath: String, serConf:SparkSeria
     }
 
     /* Local Time formatting */
-    for (format <- List(DateTimeFormatter.ISO_LOCAL_DATE_TIME)) {
+    for (format <- localTimeFormat2.keySet) {
       var instant: Instant = null
       try {
         val localDateTime = LocalDateTime.parse(dateString, format)
         instant = localDateTime.atZone(ZoneId.systemDefault()).toInstant();
-        return ChronoUnit.MICROS.between(Instant.EPOCH, instant)
+        val res = ChronoUnit.MICROS.between(Instant.EPOCH, instant)
+        indexToCachedDateTimeFunction(index) = (format, localTimeFormat2(format))
+        return res
       } catch {
         case e: ArithmeticException => {
+          indexToCachedDateTimeFunction(index) = (format, localTimeFormat2(format))
           return instant.toEpochMilli()*1000
         }
         case e: DateTimeParseException =>
@@ -198,16 +295,19 @@ class CSVReaderConnector(httpPrefix:String, filePath: String, serConf:SparkSeria
     }
 
     /* Non-common formats in local time */
-    for (formatString <- localTimeFormatsNonStandard) {
+    for (formatString <- localTimeFormatsNonStandard.keySet) {
       var instant: Instant = null
       try {
         val dateTimeFormatter = DateTimeFormatter.ofPattern(formatString)
         val localDateTime = LocalDateTime.parse(dateString, dateTimeFormatter)
         /* Assume non-standard times are in UTC */
         instant =  localDateTime.atZone(ZoneId.of("UTC")).toInstant();
-        return ChronoUnit.MICROS.between(Instant.EPOCH, instant)
+        val res = ChronoUnit.MICROS.between(Instant.EPOCH, instant)
+        indexToCachedDateTimeFunction(index) = (formatString, localTimeFormatsNonStandard(formatString))
+        return res
       } catch {
         case e: ArithmeticException => {
+          indexToCachedDateTimeFunction(index) = (formatString, localTimeFormatsNonStandard(formatString))
           return instant.toEpochMilli()*1000
         }
         case e: DateTimeParseException =>
@@ -215,16 +315,19 @@ class CSVReaderConnector(httpPrefix:String, filePath: String, serConf:SparkSeria
     }
 
     /* Just Dates (no-time element) formats formatting */
-    for (formatString <- dateFormatStrings) {
+    for (formatString <- dateFormatStringsAsDateTime.keySet) {
       var instant: Instant = null
       try {
         val dateTimeFormatter = DateTimeFormatter.ofPattern(formatString)
         val localDate = LocalDate.parse(dateString, dateTimeFormatter)
         val localDateTime1 = localDate.atStartOfDay();
         instant = localDateTime1.atZone(ZoneId.of("UTC")).toInstant();
-        return ChronoUnit.MICROS.between(Instant.EPOCH, instant)
+        val res = ChronoUnit.MICROS.between(Instant.EPOCH, instant)
+        indexToCachedDateTimeFunction(index) = (formatString, dateFormatStringsAsDateTime(formatString))
+        return res
       } catch {
         case e: ArithmeticException => {
+          indexToCachedDateTimeFunction(index) = (formatString, dateFormatStringsAsDateTime(formatString))
           return instant.toEpochMilli()*1000
         }
         case e: DateTimeParseException =>
@@ -232,27 +335,121 @@ class CSVReaderConnector(httpPrefix:String, filePath: String, serConf:SparkSeria
     }
 
     /* Finally, this could just be a Time - Try that */
-    for (formatString <- timeFormatStrings) {
+    for (formatString <- timeFormatStrings.keySet) {
       var instant: Instant = null
       try {
         val formatterTime1 = DateTimeFormatter.ofPattern(formatString)
         val ls = LocalTime.parse(dateString, formatterTime1)
         instant = ls.atDate(LocalDate.of(1970, 1, 1)).atZone(ZoneId.of("UTC")).toInstant
-        return ChronoUnit.MICROS.between(Instant.EPOCH, instant)
+        val res = ChronoUnit.MICROS.between(Instant.EPOCH, instant)
+        indexToCachedDateTimeFunction(index) = (formatString, timeFormatStrings(formatString))
+        return res
       } catch {
         case e: ArithmeticException => {
+          indexToCachedDateTimeFunction(index) = (formatString, timeFormatStrings(formatString))
           return instant.toEpochMilli()*1000
         }
         case e: DateTimeParseException =>
       }
     }
 
-
-    val msg = "Mode: " + mode + ". Could not parse " + dateString + " using any possible format"
+    val msg = s"Mode: $mode. Could not parse \'$dateString\'. Data in this format is not supported."
     SparkCDMLogger.log(Level.ERROR,  msg, logger)
     if (Constants.FAILFAST.equalsIgnoreCase(mode)) {
       throw new IllegalArgumentException(msg)
     }
     null
+  }
+
+  // DATE PARSING
+  private def parseGenericDateCached1(dateString: String, format: Any, index: Int, mode: String) : LocalDate = {
+    try {
+      val dateTimeFormatter = DateTimeFormatter.ofPattern(format.asInstanceOf[String])
+      return LocalDate.parse(dateString, dateTimeFormatter)
+    } catch {
+      case e: DateTimeParseException=>
+    }
+    return checkFailFast(dateString, format, index, mode)
+  }
+
+  // DATETIME PARSING
+  private def parseGenericDateTimeCached1(dateString: String, format: Any, index: Int, mode: String) : java.lang.Long = {
+    var instant: Instant = null;
+    try {
+      val i = Instant.from(format.asInstanceOf[DateTimeFormatter].parse(dateString))
+      val zt = i.atZone(ZoneId.systemDefault())
+      instant = zt.toLocalDateTime.atZone(ZoneId.systemDefault()).toInstant();
+      return ChronoUnit.MICROS.between(Instant.EPOCH, instant)
+    } catch {
+      case e: ArithmeticException => { return instant.toEpochMilli()*1000 }
+      case e: DateTimeParseException=>
+    }
+    return checkFailFast(dateString, format, index, mode)
+  }
+
+  private def parseGenericDateTimeCached2(dateString: String, format: Any, index: Int, mode: String) : java.lang.Long = {
+    var instant: Instant = null
+    try {
+      val localDateTime = LocalDateTime.parse(dateString, format.asInstanceOf[DateTimeFormatter])
+      instant = localDateTime.atZone(ZoneId.systemDefault()).toInstant();
+      return ChronoUnit.MICROS.between(Instant.EPOCH, instant)
+    } catch {
+      case e: ArithmeticException => { return instant.toEpochMilli()*1000 }
+      case e: DateTimeParseException =>
+    }
+    return checkFailFast(dateString, format, index, mode)
+  }
+
+  private def parseGenericDateTimeCached3(dateString: String, format: Any, index: Int, mode: String) : java.lang.Long = {
+    var instant: Instant = null
+    try {
+      val dateTimeFormatter = DateTimeFormatter.ofPattern(format.asInstanceOf[String])
+      val localDateTime = LocalDateTime.parse(dateString, dateTimeFormatter)
+      /* Assume non-standard times are in UTC */
+      instant =  localDateTime.atZone(ZoneId.of("UTC")).toInstant();
+      return ChronoUnit.MICROS.between(Instant.EPOCH, instant)
+    } catch {
+      case e: ArithmeticException => { return instant.toEpochMilli()*1000 }
+      case e: DateTimeParseException =>
+    }
+    return checkFailFast(dateString, format, index, mode)
+  }
+
+  private def parseGenericDateTimeCached4(dateString: String, format: Any, index: Int, mode: String) : java.lang.Long = {
+    var instant: Instant = null
+    try {
+      val dateTimeFormatter = DateTimeFormatter.ofPattern(format.asInstanceOf[String])
+      val localDate = LocalDate.parse(dateString, dateTimeFormatter)
+      val localDateTime1 = localDate.atStartOfDay();
+      instant = localDateTime1.atZone(ZoneId.of("UTC")).toInstant();
+      return ChronoUnit.MICROS.between(Instant.EPOCH, instant)
+    } catch {
+      case e: ArithmeticException => { return instant.toEpochMilli()*1000 }
+      case e: DateTimeParseException =>
+    }
+    return checkFailFast(dateString, format, index, mode)
+  }
+
+  private def parseGenericDateTimeCached5(dateString: String, format: Any, index: Int, mode: String) : java.lang.Long = {
+    var instant: Instant = null
+    try {
+      val formatterTime1 = DateTimeFormatter.ofPattern(format.asInstanceOf[String])
+      val ls = LocalTime.parse(dateString, formatterTime1)
+      instant = ls.atDate(LocalDate.of(1970, 1, 1)).atZone(ZoneId.of("UTC")).toInstant
+      return ChronoUnit.MICROS.between(Instant.EPOCH, instant)
+    } catch {
+      case e: ArithmeticException => { return instant.toEpochMilli()*1000 }
+      case e: DateTimeParseException =>
+    }
+    return checkFailFast(dateString, format, index, mode)
+  }
+
+  private def checkFailFast(dateString: String, format: Any, index: Int, mode: String) : Null = {
+    val msg = s"Mode: $mode. Each item in a column must have the same format. Column $index, item \'$dateString\' does not match the cached format \'$format\'."
+    SparkCDMLogger.log(Level.ERROR, msg, logger)
+    if (Constants.FAILFAST.equalsIgnoreCase(mode)) {
+      throw new IllegalArgumentException(msg)
+    }
+    return null
   }
 }

--- a/src/main/scala/com/microsoft/cdm/read/ParquetReaderConnector.scala
+++ b/src/main/scala/com/microsoft/cdm/read/ParquetReaderConnector.scala
@@ -207,14 +207,14 @@ class ParquetReaderConnector(httpPrefix: String,
 
   def isValidRow(): Boolean = true
 
-  def jsonToData(dt: DataType, value: Any, mode: String): Any = {
+  def jsonToData(dt: DataType, value: Any, schemaIndex: Int, mode: String): Any = {
     return dt match {
       case ar: ArrayType => {
         util.Try({
           val structs = value.toString.split(" ")
           val seq = structs.zipWithIndex.map{ case (col, index) =>
             val dataType = ar.elementType
-            jsonToData(dataType, col, mode)
+            jsonToData(dataType, col, schemaIndex, mode)
           }
           ArrayData.toArrayData(seq)
         }).getOrElse(null)
@@ -242,7 +242,7 @@ class ParquetReaderConnector(httpPrefix: String,
           val arr = deSerializeObject(value.toString.getBytes());
           val seq = arr.zipWithIndex.map { case (col, index) =>
             val dataType = st.fields(index).dataType
-            jsonToData(dataType, col, mode)
+            jsonToData(dataType, col, schemaIndex, mode)
           }
           val isAllNull = arr.forall(x => x == null)
           if (isAllNull) null else InternalRow.fromSeq(seq)

--- a/src/main/scala/com/microsoft/cdm/read/ReaderConnector.scala
+++ b/src/main/scala/com/microsoft/cdm/read/ReaderConnector.scala
@@ -26,9 +26,10 @@ trait ReaderConnector extends Serializable {
    * This method is to used to convert to Spark/CDM data types
    * @param dataType
    * @param col
+   * @param schemaIndex Used in CSVReaderConnector for schema mapping. In ParquetReaderConnector, it has no functional purpose other than keeping the same interface.
    * @return
    */
-  def jsonToData(dataType: DataType, col: Any, mode: String): Any
+  def jsonToData(dataType: DataType, col: Any, schemaIndex: Int, mode: String): Any
 
 
   def isValidRow(): Boolean


### PR DESCRIPTION
Cache the Date and DateTime methods by reading the first row and then mapping **index** to a **(format, function)** tuple. On a subsequent read, the executor will automatically pass in the index, and if it's a CDM Date or DateTime type, it will use the map to directly use the cached method to parse all future inputs. This increases the scalability and performance by selecting the right function to execute in constant O(1) time vs O(N) time, where N is the number of formats needed to check.

**Restrictions:**
- Each column must have the same format, otherwise an exception will be thrown (when using failfast). If permissive mode is used, then those with a different format will be turned into null